### PR TITLE
Update render-readme.yaml

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -20,7 +20,7 @@ jobs:
       
       # Install packages needed
       - name: install required packages
-        run: Rscript -e 'install.packages(c("devtools", "rmarkdown", "yamlme"))'
+        run: Rscript -e 'install.packages(c("remotes", "rmarkdown", "yamlme"))'
       
       # Install packages needed from GitHub
       - name: install from GitHub


### PR DESCRIPTION
Hey, I saw your comment on: https://fromthebottomoftheheap.net/2020/04/30/rendering-your-readme-with-github-actions/ It wouldn't let me log in to reply to you so I thought I'd just suggest a change here.

Using `remotes` instead of `devtools` should speed up the install time and therefor the whole job considerably!